### PR TITLE
fix: urls in commit message triggering jira-task-id-empty

### DIFF
--- a/packages/commitlint-jira-utils/src/parseCommitMessage.ts
+++ b/packages/commitlint-jira-utils/src/parseCommitMessage.ts
@@ -21,7 +21,7 @@ const parseCommitMessage: TParseCommitMessage = commitMessage => {
     commitTaskIds: commitHeader
       .split(COMMIT_TASK_IDS_SEPARATOR)
       .map(taskId => taskId.trim())
-      .filter(taskId => taskId),
+      .filter(taskId => taskId && taskId.search(/\w+.*[0-9]+/) === 0),
     commitFooter: commitFooter.trim(),
     commitHeader: commitHeader.trim(),
     commitStatus: commitStatus.trim(),

--- a/packages/commitlint-plugin-jira-rules/src/rules/tests/jiraTaskIdMinLengthRuleResolver.test.ts
+++ b/packages/commitlint-plugin-jira-rules/src/rules/tests/jiraTaskIdMinLengthRuleResolver.test.ts
@@ -13,4 +13,10 @@ describe('jiraTaskIdMinLengthRuleResolver', () => {
     }
     expect(jiraTaskIdMinLengthRuleResolver(parsed)[0]).toEqual(true)
   })
+  it('should return a success response if there is an URL in the commit message', () => {
+    const parsed = {
+      raw: 'IB-21: my commit message\nhttps://mytestwebsite.com/IB-21',
+    }
+    expect(jiraTaskIdMinLengthRuleResolver(parsed)[0]).toEqual(true)
+  })
 })


### PR DESCRIPTION
This PR fixes the aforementioned bug of urls in commit messages triggering jira-task-id-empty.

Explanation: the parser now uses a regex alongside the task id separator splitting.
The regex makes sure every hit follows the convention of at least one alpha numeric character (or more), followed by an optional character (the separator) and a string of numbers.
It also makes sure that every hit the regex finds is the start of the string we split.