### PR TITLE
fix: commit message separator in jira-task-id-empty

### DIFF
--- a/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdEmptyRuleResolver.ts
+++ b/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdEmptyRuleResolver.ts
@@ -4,7 +4,11 @@ import {
 } from 'commitlint-jira-utils'
 import { TRuleResolver } from '../../@types'
 
-const jiraTaskIdEmptyRuleResolver: TRuleResolver = parsed => {
+const jiraTaskIdEmptyRuleResolver: TRuleResolver = (
+  parsed,
+  _when,
+  commitMessageSeparator = commitlintJiraConstants.COMMIT_MESSAGE_SEPARATOR
+) => {
   const rawCommitMessage = parsed.raw
   if (!rawCommitMessage) return [false, 'Commit message should not be empty']
 
@@ -13,7 +17,7 @@ const jiraTaskIdEmptyRuleResolver: TRuleResolver = parsed => {
   const isRuleValid = commitMessage.commitTaskIds.length > 0
   return [
     isRuleValid,
-    `the commit message must provide minimum one task id followed by (${commitlintJiraConstants.COMMIT_MESSAGE_SEPARATOR}) symbol, if task not have an id use a conventional task id e.g: "IB-0000${commitlintJiraConstants.COMMIT_MESSAGE_SEPARATOR} My commit message"`,
+    `the commit message must provide minimum one task id followed by (${commitMessageSeparator}) symbol, if task not have an id use a conventional task id e.g: "IB-0000${commitMessageSeparator} My commit message"`,
   ]
 }
 export default jiraTaskIdEmptyRuleResolver


### PR DESCRIPTION
maybe a partial solution...
this requires to replicate rules