### PR TITLE
fix: Update missing and mispelled words in rule error messages

### DIFF
--- a/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdEmptyRuleResolver.ts
+++ b/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdEmptyRuleResolver.ts
@@ -13,7 +13,7 @@ const jiraTaskIdEmptyRuleResolver: TRuleResolver = parsed => {
   const isRuleValid = commitMessage.commitTaskIds.length > 0
   return [
     isRuleValid,
-    `the commit message must provide minimum one task id followed by (${commitlintJiraConstants.COMMIT_MESSAGE_SEPARATOR}) symbol, if task not have an id use a conventional task id e.g: "IB-0000${commitlintJiraConstants.COMMIT_MESSAGE_SEPARATOR} My commit message"`,
+    `the commit message must provide minimum one task id followed by (${commitlintJiraConstants.COMMIT_MESSAGE_SEPARATOR}) symbol, if task does not have an id use a conventional task id e.g: "IB-0000${commitlintJiraConstants.COMMIT_MESSAGE_SEPARATOR} My commit message"`,
   ]
 }
 export default jiraTaskIdEmptyRuleResolver

--- a/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdMaxLengthRuleResolver.ts
+++ b/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdMaxLengthRuleResolver.ts
@@ -19,7 +19,7 @@ const jiraTaskIdMaxLengthRuleResolver: TRuleResolver = (
 
   return [
     isRuleValid,
-    `${nonValidTaskId} taskId must not be loonger than ${value} characters`,
+    `${nonValidTaskId} taskId must not be longer than ${value} characters`,
   ]
 }
 export default jiraTaskIdMaxLengthRuleResolver

--- a/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdMinLengthRuleResolver.ts
+++ b/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdMinLengthRuleResolver.ts
@@ -19,7 +19,7 @@ const jiraTaskIdMinLengthRuleResolver: TRuleResolver = (
 
   return [
     isRuleValid,
-    `${nonValidTaskId} taskId must not be shorten than ${value} characters`,
+    `${nonValidTaskId} taskId must not be shorter than ${value} characters`,
   ]
 }
 

--- a/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdProjectKeyRuleResolver.ts
+++ b/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdProjectKeyRuleResolver.ts
@@ -18,7 +18,7 @@ const jiraTaskIdProjectKeyRuleResolver: TRuleResolver = (
     return [true]
   }
   if (typeof value !== 'string' && !Array.isArray(value) && value) {
-    return [false, 'jira project key should be a string or an array of strings']
+    return [false, 'invalid rule option - jira project key should be a string or an array of strings']
   }
 
   commitMessage.commitTaskIds.forEach(taskId => {


### PR DESCRIPTION
This PR fixes a few spelling errors that I found inside of some of the validation messages that are shown to the user.

* if task not have an id > if task **does** not have an id
* loonger > **longer**
* be shorten than > be **shorter** than

I also added some additional context to one of the validation messages in jiraTaskIdProjectKeyRule to make it clearer that the error is due to a bad rule option rather than a bad commit message