### PR TITLE
fix: ensure ticketId is set in ProjectKeyRule error message

### DIFF
--- a/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdProjectKeyRuleResolver.ts
+++ b/packages/commitlint-plugin-jira-rules/src/rules/jiraTaskIdProjectKeyRuleResolver.ts
@@ -22,20 +22,26 @@ const jiraTaskIdProjectKeyRuleResolver: TRuleResolver = (
   }
 
   commitMessage.commitTaskIds.forEach(taskId => {
-    if (typeof value === 'string' && new RegExp(`^${value}`).test(taskId)) {
-      nonValidTaskId = taskId
+    let matchFound = false
+    if (typeof value === 'string') {
+      matchFound = matchFound || new RegExp(`^${value}`).test(taskId)
     }
 
     if (Array.isArray(value)) {
       value.forEach(projectKey => {
-        if (new RegExp(`^${projectKey}`).test(taskId)) {
-          nonValidTaskId = taskId
-        }
+        matchFound = matchFound || new RegExp(`^${projectKey}`).test(taskId)
       })
+      if (!matchFound) {
+        nonValidTaskId = taskId
+      }
+    }
+
+    if (!matchFound) {
+      nonValidTaskId = taskId
     }
   })
 
-  isRuleValid = !!nonValidTaskId
+  isRuleValid = nonValidTaskId === null
 
   return [
     isRuleValid,

--- a/packages/commitlint-plugin-jira-rules/src/rules/tests/jiraTaskIdProjectKeyRuleResolver.test.ts
+++ b/packages/commitlint-plugin-jira-rules/src/rules/tests/jiraTaskIdProjectKeyRuleResolver.test.ts
@@ -17,6 +17,17 @@ describe('jiraTaskIdProjectKeyRuleResolver', () => {
       jiraTaskIdProjectKeyRuleResolver(parsed, undefined, 'PRJT')[0],
     ).toEqual(false)
   })
+  it('should include invalid task id and the expected project id in error message', () => {
+    const parsed = {
+      raw: 'IB-21: my commit message',
+    }
+    expect(
+      jiraTaskIdProjectKeyRuleResolver(parsed, undefined, 'PRJT')[1],
+    ).toMatch(new RegExp('^IB-21'))
+    expect(
+      jiraTaskIdProjectKeyRuleResolver(parsed, undefined, 'PRJT')[1],
+    ).toMatch(new RegExp('PRJT$'))
+  })
   it('should return a error response if task id does not include any project keys', () => {
     const parsed = {
       raw: 'IB-21: my commit message',
@@ -25,6 +36,27 @@ describe('jiraTaskIdProjectKeyRuleResolver', () => {
     expect(
       jiraTaskIdProjectKeyRuleResolver(parsed, undefined, value)[0],
     ).toEqual(false)
+  })
+  it('should return an error response if any of multiple task ids do not include any project keys', () => {
+    const parsed = {
+      raw: 'PRJT-21, IB-21: my commit message',
+    }
+    const value = ['PRJT', 'PRJT2']
+    expect(
+      jiraTaskIdProjectKeyRuleResolver(parsed, undefined, value)[0],
+    ).toEqual(false)
+  })
+  it('should include the invalid task id and the expected project ids in the error message when using multiple tasks and projects', () => {
+    const parsed = {
+      raw: 'PRJT-21, IB-21, PRJT2-21: my commit message',
+    }
+    const value = ['PRJT', 'PRJT2']
+    expect(
+      jiraTaskIdProjectKeyRuleResolver(parsed, undefined, value)[1],
+    ).toMatch(new RegExp('^IB-21'))
+    expect(
+      jiraTaskIdProjectKeyRuleResolver(parsed, undefined, value)[1],
+    ).toMatch(new RegExp('PRJT,PRJT2$'))
   })
   it('should return a success response if project key is set to false', () => {
     const parsed = {
@@ -55,6 +87,15 @@ describe('jiraTaskIdProjectKeyRuleResolver', () => {
         'PRJT2',
         'PRJT',
       ])[0],
+    ).toEqual(true)
+  })
+  it('should return a success response if all task ids include one of the project keys', () => {
+    const parsed = {
+      raw: 'PRJT-21, PRJT2-21: my commit message',
+    }
+    const value = ['PRJT', 'PRJT2']
+    expect(
+      jiraTaskIdProjectKeyRuleResolver(parsed, undefined, value)[0],
     ).toEqual(true)
   })
 })


### PR DESCRIPTION
When the `jira-task-id-project-key` rule failed, the `nonValidTaskId` was always `null` because the "if" conditionals were only setting it when the RegExp result was `TRUE` (during success). This would result in the message always starting with `null`:
> null taskId must start with project key PRJT [jira-task-id-project-key]

This PR fixes the bug and also adds a few additional tests to verify that passing more than 1 task-ids in a commit message also works
>  IB-21 taskId must start with project key PRJT [jira-task-id-project-key]